### PR TITLE
IEBH-479: Handle missing memberuser_user in hbac_rule response

### DIFF
--- a/app/services/data_providers/freeipa_client.py
+++ b/app/services/data_providers/freeipa_client.py
@@ -86,7 +86,7 @@ class FreeIPAClient:
             return {
                 'name': hbac_rule['result'][0]['cn'][0],
                 'description': hbac_rule['result'][0]['description'][0],
-                'members': hbac_rule['result'][0]['memberuser_user'],
+                'members': hbac_rule['result'][0].get('memberuser_user', []),
                 'dn': hbac_rule['result'][0]['dn'],
             }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "service_auth"
-version = "2.2.38"
+version = "2.2.39"
 description = ""
 authors = ["Indoc Research <admin@indocresearch.org>"]
 


### PR DESCRIPTION
Fix situation when hbac rule can't be obtained.